### PR TITLE
cleared fields upon adding

### DIFF
--- a/bookmarks-front-end/src/App.js
+++ b/bookmarks-front-end/src/App.js
@@ -38,6 +38,7 @@ class App extends Component {
   async addBookmark(title, url) {
     await this.backend.addBookmark(title, url)
     this.refresh()
+
   }
 
   async deleteBookmark(id) {

--- a/bookmarks-front-end/src/Backend.js
+++ b/bookmarks-front-end/src/Backend.js
@@ -17,6 +17,7 @@ class Backend {
         title: title,
         url: url
       })
+
   }
 
   async deleteBookmark(id) {

--- a/bookmarks-front-end/src/components/NewBookmark.js
+++ b/bookmarks-front-end/src/components/NewBookmark.js
@@ -24,6 +24,10 @@ class NewBoookmark extends Component {
     handleSubmit(event) {
         event.preventDefault()
         this.props.addBookmark(this.state.title, this.state.url);
+        this.setState({
+            title: '',
+            url: ''
+        });
     }
 
     render() {


### PR DESCRIPTION
There was a bug when a values for each new added item were kept in the input fields.
Now the state of the fields is reset to blank after a new entry is made.